### PR TITLE
refactor(api): use SettingsConfigDict for env config

### DIFF
--- a/apps/api/settings.py
+++ b/apps/api/settings.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -12,10 +13,7 @@ class Settings(BaseSettings):
     cors_origin: str = Field("http://localhost:3000", alias="CORS_ORIGIN")
     api_port: int = Field(5050, alias="API_PORT")
 
-    class Config:
-        env_file = ".env"
-        extra = "ignore"
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 
-settings = Settings(_env_file=".env", _secrets_dir=None)
-
+settings = Settings(_secrets_dir=None)


### PR DESCRIPTION
## Summary
- replace Settings Config class with `SettingsConfigDict`
- handle env file and extra fields via `model_config`
- simplify Settings instantiation

## Testing
- `ruff check apps/api/settings.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689843f431d88333b77490eca15a5fd6