### PR TITLE
feat(api): forbid extra fields in request models

### DIFF
--- a/apps/api/routers/fs.py
+++ b/apps/api/routers/fs.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import List, Optional
 from pathlib import Path
 
@@ -8,14 +8,21 @@ from services.fs import safe_join
 
 router = APIRouter()
 
+
 class FsItem(BaseModel):
     name: str
     path: str  # path relative to project root
     dir: bool
 
+    model_config = ConfigDict(extra="forbid")
+
+
 class WriteBody(BaseModel):
     path: str
     content: str
+
+    model_config = ConfigDict(extra="forbid")
+
 
 MAX_TEXT_BYTES = 1_000_000  # 1MB safeguard
 
@@ -23,45 +30,61 @@ MAX_TEXT_BYTES = 1_000_000  # 1MB safeguard
 class PathBody(BaseModel):
     path: str
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class MkdirBody(BaseModel):
     path: str
     parents: bool = True
+
+    model_config = ConfigDict(extra="forbid")
 
 
 class CreateBody(BaseModel):
     path: str
     content: Optional[str] = ""
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class MoveBody(BaseModel):
     src: str
     dst: str
 
+    model_config = ConfigDict(extra="forbid")
+
+
 def _abs_from_rel(rel: str) -> Path:
     root = settings.project_root
     return Path(safe_join(root, rel or "."))
+
 
 def _rel_from_abs(abs_path: Path) -> str:
     root = Path(settings.project_root).resolve()
     return str(abs_path.resolve().relative_to(root))
 
+
 @router.get("/fs/list", response_model=List[FsItem])
-def list_dir(path: str = Query(default="", description="Relative path from PROJECT_ROOT")):
+def list_dir(
+    path: str = Query(default="", description="Relative path from PROJECT_ROOT")
+):
     target = _abs_from_rel(path)
     if not target.exists():
         raise HTTPException(status_code=404, detail="Path not found")
     if target.is_file():
         target = target.parent
     items: List[FsItem] = []
-    for child in sorted(target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
-        items.append(FsItem(name=child.name, path=_rel_from_abs(child), dir=child.is_dir()))
+    for child in sorted(
+        target.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())
+    ):
+        items.append(
+            FsItem(name=child.name, path=_rel_from_abs(child), dir=child.is_dir())
+        )
     return items
 
 
 @router.get("/fs/tree", response_model=List[str])
 def tree(path: str = ""):
-    root = Path(settings.project_root).resolve()
     start = _abs_from_rel(path)
     if not Path(start).exists():
         raise HTTPException(status_code=404, detail="Path not found")
@@ -77,6 +100,7 @@ def tree(path: str = ""):
             continue
     return results
 
+
 @router.get("/fs/read")
 def read_file(path: str = Query(..., description="Relative file path")):
     p = _abs_from_rel(path)
@@ -85,7 +109,9 @@ def read_file(path: str = Query(..., description="Relative file path")):
     # Size guard
     size = p.stat().st_size
     if size > MAX_TEXT_BYTES:
-        raise HTTPException(status_code=413, detail=f"File too large (> {MAX_TEXT_BYTES} bytes)")
+        raise HTTPException(
+            status_code=413, detail=f"File too large (> {MAX_TEXT_BYTES} bytes)"
+        )
     # Basic binary detection
     head = p.read_bytes()[:2048]
     if b"\x00" in head:
@@ -95,6 +121,7 @@ def read_file(path: str = Query(..., description="Relative file path")):
     except UnicodeDecodeError:
         raise HTTPException(status_code=415, detail="Not a UTF-8 text file")
     return {"path": path, "content": content}
+
 
 @router.post("/fs/write")
 def write_file(body: WriteBody):
@@ -107,7 +134,9 @@ def write_file(body: WriteBody):
     except Exception:
         raise HTTPException(status_code=400, detail="Content must be UTF-8 encodable")
     if len(payload_bytes) > MAX_TEXT_BYTES:
-        raise HTTPException(status_code=413, detail=f"Content too large (> {MAX_TEXT_BYTES} bytes)")
+        raise HTTPException(
+            status_code=413, detail=f"Content too large (> {MAX_TEXT_BYTES} bytes)"
+        )
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(body.content, encoding="utf-8")
     return {"ok": True}
@@ -117,7 +146,9 @@ def write_file(body: WriteBody):
 def mkdir(body: MkdirBody):
     p = _abs_from_rel(body.path)
     if Path(settings.project_root).resolve() == Path(p).resolve():
-        raise HTTPException(status_code=400, detail="Refusing to create the project root")
+        raise HTTPException(
+            status_code=400, detail="Refusing to create the project root"
+        )
     Path(p).mkdir(parents=body.parents, exist_ok=True)
     return {"ok": True}
 
@@ -131,7 +162,9 @@ def create_file(body: CreateBody):
     pp.parent.mkdir(parents=True, exist_ok=True)
     content = (body.content or "").encode("utf-8")
     if len(content) > MAX_TEXT_BYTES:
-        raise HTTPException(status_code=413, detail=f"Content too large (> {MAX_TEXT_BYTES} bytes)")
+        raise HTTPException(
+            status_code=413, detail=f"Content too large (> {MAX_TEXT_BYTES} bytes)"
+        )
     pp.write_bytes(content)
     return {"ok": True}
 

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import Any, Dict
 
 
@@ -8,9 +8,12 @@ class Out(BaseModel):
     messageId: str
     payload: Dict[str, Any]
 
+    model_config = ConfigDict(extra="forbid")
+
 
 class In(BaseModel):
     type: str
     messageId: str
     payload: Dict[str, Any]
 
+    model_config = ConfigDict(extra="forbid")

--- a/apps/api/tests/test_fs_validation.py
+++ b/apps/api/tests/test_fs_validation.py
@@ -1,0 +1,26 @@
+import sys
+import types
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_write_rejects_unknown_fields(tmp_path):
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+    settings_module = types.ModuleType("settings")
+    settings_module.settings = types.SimpleNamespace(project_root=str(tmp_path))
+    sys.modules["settings"] = settings_module
+
+    from routers.fs import router
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    client = TestClient(app)
+
+    resp = client.post(
+        "/api/fs/write",
+        json={"path": "a.txt", "content": "hi", "extra": "nope"},
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- add `ConfigDict(extra='forbid')` to fs router request/response models and core schemas
- ensure FastAPI rejects payloads with unknown fields
- add test confirming `/api/fs/write` returns 422 on unexpected keys

## Testing
- `ruff check apps/api/routers/fs.py apps/api/schemas.py apps/api/tests/test_fs_validation.py`
- `pytest apps/api/tests/test_fs_validation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689843f9e3f88333a428227bf3b06d6a