### PR TITLE
feat(web): add file tabs component

### DIFF
--- a/apps/web/src/app/(studio)/page.tsx
+++ b/apps/web/src/app/(studio)/page.tsx
@@ -24,8 +24,12 @@ export default function Studio() {
             </Panel>
             <PanelResizeHandle className="h-1 bg-zinc-900 hover:bg-zinc-800 cursor-row-resize" />
             <Panel defaultSize={33} minSize={20} className="border-b overflow-hidden">
-              <Tabs />
-              <EditorPane />
+              <div className="flex flex-col h-full">
+                <Tabs />
+                <div className="flex-1">
+                  <EditorPane />
+                </div>
+              </div>
             </Panel>
             <PanelResizeHandle className="h-1 bg-zinc-900 hover:bg-zinc-800 cursor-row-resize" />
             <Panel defaultSize={33} minSize={15} className="overflow-hidden">

--- a/apps/web/src/components/Tabs.tsx
+++ b/apps/web/src/components/Tabs.tsx
@@ -1,0 +1,44 @@
+'use client'
+import clsx from 'clsx'
+import { X } from 'lucide-react'
+import { useStudio } from '@/lib/store'
+
+export default function Tabs() {
+  const open = useStudio(s => s.open)
+  const active = useStudio(s => s.filePath)
+  const closeFile = useStudio(s => s.closeFile)
+  const setActive = useStudio(s => s.setActive)
+
+  if (open.length === 0) return null
+
+  return (
+    <div className="flex border-b border-zinc-800 bg-zinc-950/40 text-xs overflow-x-auto select-none">
+      {open.map(path => {
+        const name = path.split('/').pop() || path
+        const isActive = path === active
+        return (
+          <div
+            key={path}
+            className={clsx(
+              'group flex items-center gap-2 px-3 py-1 cursor-pointer border-r border-zinc-800',
+              isActive ? 'bg-zinc-800 text-zinc-100' : 'text-zinc-400 hover:bg-zinc-800/60'
+            )}
+            onClick={() => setActive(path)}
+            title={path}
+          >
+            <span className="truncate max-w-[10rem]">{name}</span>
+            <button
+              className="opacity-0 group-hover:opacity-100 text-zinc-500 hover:text-zinc-300"
+              onClick={e => {
+                e.stopPropagation()
+                closeFile(path)
+              }}
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </div>
+        )
+      })}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Tabs component for switching between open files
- wrap editor panel with tabs in Studio layout

## Testing
- `pnpm --filter @codex-studio/web build` *(fails: Cannot find module 'autoprefixer' and tailwind PostCSS plugin)*

------
https://chatgpt.com/codex/tasks/task_e_689845405298833383508f05fe5a7b40