### PR TITLE
fix: add dev api scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "codex-studio",
   "private": true,
+  "packageManager": "pnpm@10.5.2",
   "devDependencies": {
     "turbo": "latest"
   },

--- a/scripts/dev_api.ps1
+++ b/scripts/dev_api.ps1
@@ -1,0 +1,18 @@
+Param()
+$ErrorActionPreference = "Stop"
+
+$ROOT = Resolve-Path "$PSScriptRoot/.."
+$PORT = $Env:API_PORT
+if (-not $PORT) { $PORT = 5050 }
+
+Set-Location "$ROOT/apps/api"
+
+if (Test-Path ".venv/Scripts/Activate.ps1") {
+  . ".venv/Scripts/Activate.ps1"
+}
+
+if (-not $Env:PROJECT_ROOT) {
+  $Env:PROJECT_ROOT = $ROOT
+}
+
+python -m uvicorn main:app --reload --port $PORT

--- a/scripts/dev_api.sh
+++ b/scripts/dev_api.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine repository root relative to this script
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${API_PORT:-5050}"
+
+cd "$ROOT/apps/api"
+
+# Activate virtual environment if present
+if [ -f ".venv/bin/activate" ]; then
+  source .venv/bin/activate
+fi
+
+# Ensure PROJECT_ROOT is set so settings can validate
+export PROJECT_ROOT="${PROJECT_ROOT:-$ROOT}"
+
+python -m uvicorn main:app --reload --port "$PORT"


### PR DESCRIPTION
## Summary
- declare pnpm as the workspace package manager
- add cross-platform scripts for dev:api

## Testing
- `pnpm install`
- `pip install -r apps/api/requirements.txt`
- `PROJECT_ROOT=$PWD API_PORT=5051 timeout 3 pnpm dev:api`


------
https://chatgpt.com/codex/tasks/task_e_6898535993188333b981ddb096ab183e