### PR TITLE
fix(web): expose studio route and formatting

### DIFF
--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
     <main className="p-8 space-y-4">
       <h1 className="text-2xl font-semibold">Codex Studio</h1>
       <p className="text-zinc-400">Head to the Studio to start chatting & editing.</p>
-      <Link className="underline" href="/(studio)">
+      <Link className="underline" href="/studio">
         Open Studio
       </Link>
     </main>

--- a/apps/web/src/app/studio/page.tsx
+++ b/apps/web/src/app/studio/page.tsx
@@ -3,12 +3,14 @@ import { useEffect } from 'react'
 import Topbar from '@/components/Topbar'
 import Sidebar from '@/components/Sidebar'
 import Chat from '@/components/Chat'
-import TerminalPane from '@/components/TerminalPane'
+import dynamic from 'next/dynamic'
 import RightRail from '@/components/RightRail'
-import EditorPane from '@/components/EditorPane'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import Tabs from '@/components/Tabs'
 import QuickOpen from '@/components/QuickOpen'
+
+const EditorPane = dynamic(() => import('@/components/EditorPane'), { ssr: false })
+const TerminalPane = dynamic(() => import('@/components/TerminalPane'), { ssr: false })
 import { useStudio } from '@/lib/store'
 
 export default function Studio() {

--- a/apps/web/src/components/RightRail.tsx
+++ b/apps/web/src/components/RightRail.tsx
@@ -50,20 +50,6 @@ export default function RightRail() {
       setRunning(false)
     }
   }
-
-  async function runTests() {
-    setRunning(true)
-    setTestOut('')
-    try {
-      const out = await shellRun(['pytest', '-q'])
-      setTestOut(out.stdout || '(no output)')
-    } catch {
-      setTestOut('Failed to run tests')
-    } finally {
-      setRunning(false)
-    }
-  }
-
   async function showDiff() {
     setRunning(true)
     try {

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+"use client"
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(true)
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (dark) root.classList.add('dark')
+    else root.classList.remove('dark')
+  }, [dark])
+
+  return (
+    <button
+      className="p-1 rounded bg-zinc-800 hover:bg-zinc-700"
+      onClick={() => setDark(d => !d)}
+      title="Toggle theme"
+    >
+      {dark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </button>
+  )
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,40 @@
+export type SupportedLang =
+  | 'javascript'
+  | 'typescript'
+  | 'json'
+  | 'markdown'
+  | 'css'
+  | 'html'
+
+export async function formatWithPrettier(code: string, lang: SupportedLang): Promise<string> {
+  const prettier = await import('prettier/standalone')
+  let parser: string
+  let plugins: any[] = []
+  switch (lang) {
+    case 'javascript':
+      parser = 'babel'
+      plugins = [await import('prettier/plugins/babel'), await import('prettier/plugins/estree')]
+      break
+    case 'typescript':
+      parser = 'typescript'
+      plugins = [await import('prettier/plugins/typescript'), await import('prettier/plugins/estree')]
+      break
+    case 'json':
+      parser = 'json'
+      plugins = [await import('prettier/plugins/babel'), await import('prettier/plugins/estree')]
+      break
+    case 'markdown':
+      parser = 'markdown'
+      plugins = [await import('prettier/plugins/markdown'), await import('prettier/plugins/estree')]
+      break
+    case 'css':
+      parser = 'css'
+      plugins = [await import('prettier/plugins/postcss')]
+      break
+    case 'html':
+      parser = 'html'
+      plugins = [await import('prettier/plugins/html'), await import('prettier/plugins/estree')]
+      break
+  }
+  return prettier.format(code, { parser, plugins })
+}


### PR DESCRIPTION
## Summary
- rename studio route and link from home page
- add ThemeToggle component and client-only dynamic imports
- implement Prettier-based formatting helper

## Testing
- `pnpm build:web`

------
https://chatgpt.com/codex/tasks/task_e_68985383eaf88333985e257ccb9d7b53