### PR TITLE
feat: check terminal health before websocket

### DIFF
--- a/apps/web/src/lib/ws.ts
+++ b/apps/web/src/lib/ws.ts
@@ -1,4 +1,4 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:5050'
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? 'http://localhost:5050'
 
 function toWsUrl(httpUrl: string): string {
   try {


### PR DESCRIPTION
## Summary
- check API /health before opening terminal WebSocket
- show warning and retry when health check fails
- export `API_BASE` for reuse on client

## Testing
- `pnpm --filter @codex-studio/web lint` *(fails: requires ESLint config)*
- `pnpm test`
- `pnpm --filter @codex-studio/web build`


------
https://chatgpt.com/codex/tasks/task_e_6898584e2850833387e942e19fd9e67d